### PR TITLE
bug(#2-multiuser-conf): describes how to configure multi-user access to pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,15 @@ data:
       name: 'Dex Login Application'
       secretEnv: OIDC_CLIENT_SECRET
 ```
+
+#### Using Kubeflow Pipelines from Jupyter notebooks
+
+Since for FlexiGroBots, Kubeflow has been deployed using a multi-user mode, an additional configuration must be done so that it is possible to call Pipelines from Juypyter notebooks.
+
+For each new user, replace `<YOUR_USER_PROFILE_NAMESPACE>` in `deployment/pod_default_multiuser.yaml`.
+
+Create the new resources:
+
+```bash
+kubectl apply -f deployment/pod_default_multiuser.yaml
+```

--- a/deployment/pod_default_multiuser.yaml
+++ b/deployment/pod_default_multiuser.yaml
@@ -1,0 +1,25 @@
+apiVersion: kubeflow.org/v1alpha1
+kind: PodDefault
+metadata:
+  name: access-ml-pipeline
+  namespace: "<YOUR_USER_PROFILE_NAMESPACE>"
+spec:
+  desc: Allow access to Kubeflow Pipelines
+  selector:
+    matchLabels:
+      access-ml-pipeline: "true"
+  volumes:
+    - name: volume-kf-pipeline-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 7200
+              audience: pipelines.kubeflow.org      
+  volumeMounts:
+    - mountPath: /var/run/secrets/kubeflow/pipelines
+      name: volume-kf-pipeline-token
+      readOnly: true
+  env:
+    - name: KF_PIPELINES_SA_TOKEN_PATH
+      value: /var/run/secrets/kubeflow/pipelines/token


### PR DESCRIPTION
Documents process to grant access to Pipeplines from Jupyter notebooks following https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/#multi-user-mode