### PR TITLE
feat(#3-minio): adds minio-cli kubernetes manifests

### DIFF
--- a/minio/031-minio-cli-ingress.yaml
+++ b/minio/031-minio-cli-ingress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-cli
+  namespace: minio
+
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`minio-cli.platform.flexigrobots-h2020.eu`)
+      kind: Rule
+      services:
+        - name: minio-cli
+          port: 9000

--- a/minio/036-minio-cli-ingress-https.yml
+++ b/minio/036-minio-cli-ingress-https.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-cli-tls
+  namespace: minio
+
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`minio-cli.platform.flexigrobots-h2020.eu`)
+      kind: Rule
+      services:
+        - name: minio-cli
+          port: 9000
+  tls:
+    certResolver: default


### PR DESCRIPTION
Including manifests to deploy MinIO Console and MinIO Client in the project infrastructure, enforcing https for security purposes.
