### PR TITLE
docs(#23): add time-slicing configuration

### DIFF
--- a/kubeflow/deployment/gpu-time-slicing-config.yaml
+++ b/kubeflow/deployment/gpu-time-slicing-config.yaml
@@ -1,0 +1,19 @@
+version: v1
+flags:
+  migStrategy: "none"
+  failOnInitError: true
+  nvidiaDriverRoot: "/"
+  plugin:
+    passDeviceSpecs: false
+    deviceListStrategy: "envvar"
+    deviceIDStrategy: "uuid"
+  gfd:
+    oneshot: false
+    noTimestamp: false
+    outputFile: /etc/kubernetes/node-feature-discovery/features.d/gfd
+    sleepInterval: 60s
+sharing:
+  timeSlicing:
+    resources:
+    - name: nvidia.com/gpu
+      replicas: 2


### PR DESCRIPTION
This includes configuration steps required for enabling time-slicing on NVIDIA GPUs (this is, GPU sharing in Kubernetes).
This also adds a .yaml file required for that configuration.